### PR TITLE
Fix daylight savings time issue on the SF buoy

### DIFF
--- a/index.html
+++ b/index.html
@@ -11,6 +11,7 @@
       gtag('config', 'UA-169907378-1');
     </script>
     <script src="https://cdnjs.cloudflare.com/ajax/libs/moment.js/2.26.0/moment.js"></script>
+    <script src="https://cdnjs.cloudflare.com/ajax/libs/moment-timezone/0.5.31/moment-timezone-with-data-10-year-range.min.js"></script>
     <script src="https://cdnjs.cloudflare.com/ajax/libs/Chart.js/2.9.3/Chart.js"></script>
     <script src="https://cdnjs.cloudflare.com/ajax/libs/chartjs-plugin-annotation/0.5.7/chartjs-plugin-annotation.js"></script>
     <script src="https://cdnjs.cloudflare.com/ajax/libs/PapaParse/5.3.0/papaparse.min.js"></script>

--- a/index.js
+++ b/index.js
@@ -4,7 +4,7 @@ window.onload = function() {
   new BelchertownWind('https://www.mixdivr.org/wx/weewx/belchertown/json/homepage.json');
   new WUWind('KCASANFR69');
   new AWWind('80:7D:3A:7C:36:29');
-  new NOAAWind('urn:ioos:station:wmo:46026', 7);
+  new NOAAWind('urn:ioos:station:wmo:46026', -parseInt(moment().tz('PST8PDT').format('ZZ'))/100);
   new NWSWind('MTR/84,122');
   new NWSWind('MTR/84,124');
   new TideChart('9414290');


### PR DESCRIPTION
I forgot I hardcoded the offset in here, so the data looks like it's always >1 hour old now.  This should fix that (tested locally).