### PR TITLE
Correct date parsing when wx station local time != browser local time

### DIFF
--- a/wu-wind.js
+++ b/wu-wind.js
@@ -27,7 +27,7 @@ class WUWind extends Wind {
         var minMoment = moment().subtract(3, 'hours');
         for (var i=0; i<response.observations.length; i++) {
           var observation = response.observations[i];
-          var observationMoment = moment(observation.obsTimeLocal);
+          var observationMoment = moment.utc(observation.obsTimeUtc);
 
           // Filter out data that is not within the last three hours
           if (!observationMoment.isAfter(minMoment)) continue;


### PR DESCRIPTION
This would've caused the WU graphs to render blank if your local time is >= 3 hours from PST8PDT.