### PR TITLE
Mute the Pacifica pier webcam

### DIFF
--- a/index.html
+++ b/index.html
@@ -27,6 +27,23 @@
     <script src="nws-wind.js"></script>
     <script src="tide-chart.js"></script>
     <script src="index.js"></script>
+
+    <script async src="https://www.youtube.com/iframe_api"></script>
+    <script>
+     function onYouTubeIframeAPIReady() {
+      var player;
+      player = new YT.Player('pierVideo', {
+        videoId: 'zYi_5AF6B2A', // YouTube Video ID
+        width: 1120,               // Player width (in px)
+        height: 630,              // Player height (in px)
+        events: {
+          onReady: function(e) {
+            e.target.mute();
+          }
+        }
+      });
+     }
+    </script>
     
     <meta charset="utf-8" />
     <title>MR Weather</title>
@@ -81,7 +98,7 @@
     </a>
 
     <h3>Pacifica</h3>
-    <iframe width="1120" height="630" src="https://www.youtube.com/embed/zYi_5AF6B2A" frameborder="0" allow="accelerometer; autoplay; encrypted-media; gyroscope; picture-in-picture" allowfullscreen=""></iframe>
+    <div id="pierVideo"></div>
     <br/>
     <p>The pier points directly West, so the flag should indicate which direction the wind is pointed.  Also check for whitecaps.</p>
     <a target="_blank" href="https://www.pacificaview.net/livecam/">More Pacifica webcams...</a>


### PR DESCRIPTION
This mutes the embedded youtube vid. I tried it on firefox, chrome, and safari on my laptop and the video still works as expected but I didn't test other than that.